### PR TITLE
support python 3.11+

### DIFF
--- a/.github/workflows/run-tqsdk.yml
+++ b/.github/workflows/run-tqsdk.yml
@@ -50,24 +50,18 @@ jobs:
     strategy:
       matrix:
         envinfo:
-          # - { name: 'linux-3.7-x64', os: ubuntu-22.04, python-version: 3.7.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.8-x64', os: ubuntu-22.04, python-version: 3.8.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.9-x64', os: ubuntu-22.04, python-version: 3.9.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.10-x64', os: ubuntu-22.04, python-version: 3.10.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
           - { name: 'linux-3.11-x64', os: ubuntu-22.04, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
           - { name: 'linux-3.12-x64', os: ubuntu-22.04, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          # - { name: 'macos-3.7-x64', os: macos-15-intel, python-version: 3.7.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.8-x64', os: macos-15-intel, python-version: 3.8.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.9-x64', os: macos-15-intel, python-version: 3.9.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.10-x64', os: macos-15-intel, python-version: 3.10.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'linux-3.13-x64', os: ubuntu-22.04, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
+          - { name: 'linux-3.14-x64', os: ubuntu-22.04, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
           - { name: 'macos-3.11-x64', os: macos-15-intel, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'macos-3.12-x64', os: macos-15-intel, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          # - { name: 'windows-3.7-x64', os: windows-latest, python-version: 3.7.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.8-x64', os: windows-latest, python-version: 3.8.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.9-x64', os: windows-latest, python-version: 3.9.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.10-x64', os: windows-latest, python-version: 3.10.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'macos-3.13-x64', os: macos-15-intel, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'macos-3.14-x64', os: macos-15-intel, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'windows-3.11-x64', os: windows-latest, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
           - { name: 'windows-3.12-x64', os: windows-latest, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.13-x64', os: windows-latest, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.14-x64', os: windows-latest, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
     env:
       PYTHONUNBUFFERED: 1
       PYTHONIOENCODING: "utf-8"
@@ -98,15 +92,9 @@ jobs:
 
       # pandas 在 py>=3.8 时需要安装 pyarrow, 否则报错 DeprecationWarning：Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
       - name: Install dependencies pyarrow
-        if: matrix.envinfo.bdist-platform != 'win32' && matrix.envinfo.python-version != '3.7.x'
+        if: matrix.envinfo.bdist-platform != 'win32'
         run: |
           python -m pip install pyarrow
-
-      - name: Install dependencies on win32
-        if: matrix.envinfo.bdist-platform == 'win32' && (matrix.envinfo.python-version == '3.8.x' || matrix.envinfo.python-version == '3.9.x')
-        run: |
-          python -m pip install scipy==1.8.1
-          python -m pip install pandas==1.2.5
 
       - name: Install dependencies from requirements.txt
         run: |
@@ -166,32 +154,18 @@ jobs:
     strategy:
       matrix:
         envinfo:
-          # - { name: 'linux-3.7-x64', os: ubuntu-22.04, python-version: 3.7.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.8-x64', os: ubuntu-22.04, python-version: 3.8.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.9-x64', os: ubuntu-22.04, python-version: 3.9.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.9-x64', os: ubuntu-22.04, python-version: 3.9.x, python-arch: x64, TZ: '', bdist-platform: 'manylinux1_x86_64' }
-          - { name: 'linux-3.10-x64', os: ubuntu-22.04, python-version: 3.10.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
-          #          - { name: 'linux-3.11-x64', os: ubuntu-22.04, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64'}
-          #          - { name: 'linux-3.12-x64', os: ubuntu-22.04, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64'}
-          # - { name: 'macos-3.7-x64', os: macos-15-intel, python-version: 3.7.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.8-x64', os: macos-15-intel, python-version: 3.8.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.9-x64', os: macos-15-intel, python-version: 3.9.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'macos-3.10-x64', os: macos-15-intel, python-version: 3.10.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          #          - { name: 'macos-3.11-x64', os: macos-latest, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any'}
-          #          - { name: 'macos-3.12-x64', os: macos-latest, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any'}
-          # - { name: 'windows-3.7-x64', os: windows-latest, python-version: 3.7.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          # - { name: 'windows-3.7-x86', os: windows-latest, python-version: 3.7.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32' }
-          - { name: 'windows-3.8-x64', os: windows-latest, python-version: 3.8.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.8-x86', os: windows-latest, python-version: 3.8.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32' }
-          - { name: 'windows-3.9-x64', os: windows-latest, python-version: 3.9.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.9-x86', os: windows-latest, python-version: 3.9.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32' }
-          - { name: 'windows-3.10-x64', os: windows-latest, python-version: 3.10.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-    #          - { name: 'windows-3.10-x86', os: windows-latest, python-version: 3.10.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32'}
-    #          - { name: 'windows-3.11-x64', os: windows-latest, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64'}
-    #          - { name: 'windows-3.11-x86', os: windows-latest, python-version: 3.11.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32'}
-    #          - { name: 'windows-3.12-x64', os: windows-latest, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64'}
-    #          - { name: 'windows-3.12-x86', os: windows-latest, python-version: 3.12.x, python-arch: x86, TZ: 'CST-8', bdist-platform: 'win32'}
-    # py11 py12 默认的 hash 算法改变，导致测试脚本需要变更，暂时不加在 ci 中，后续计划只在 py11 py12 上运行 ci，需要重新录制脚本
+          - { name: 'linux-3.11-x64', os: ubuntu-22.04, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
+          - { name: 'linux-3.12-x64', os: ubuntu-22.04, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
+          - { name: 'linux-3.13-x64', os: ubuntu-22.04, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
+          - { name: 'linux-3.14-x64', os: ubuntu-22.04, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'manylinux1_x86_64' }
+          - { name: 'macos-3.11-x64', os: macos-15-intel, python-version: 3.11.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'macos-3.12-x64', os: macos-15-intel, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'macos-3.13-x64', os: macos-15-intel, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'macos-3.14-x64', os: macos-15-intel, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
+          - { name: 'windows-3.11-x64', os: windows-latest, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.12-x64', os: windows-latest, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.13-x64', os: windows-latest, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.14-x64', os: windows-latest, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
 
 
     env:
@@ -233,11 +207,6 @@ jobs:
           restore-keys: |
             ${{ matrix.envinfo.os }}-pip-
 
-      - name: Install dependencies setuptools
-        if: matrix.envinfo.python-version == '3.7.x' || matrix.envinfo.python-version == '3.8.x' || matrix.envinfo.python-version == '3.9.x'
-        run: |
-          python -m pip install setuptools==59.6.0
-
       - name: Install dependencies
         run: |
           python -c "import platform;import sys;print(sys.platform, platform.python_version(), platform.system(), platform.machine());"
@@ -249,15 +218,9 @@ jobs:
 
       # pandas 在 py>=3.8 时需要安装 pyarrow, 否则报错 DeprecationWarning：Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
       - name: Install dependencies pyarrow
-        if: matrix.envinfo.bdist-platform != 'win32' && matrix.envinfo.python-version != '3.7.x'
+        if: matrix.envinfo.bdist-platform != 'win32'
         run: |
           python -m pip install pyarrow
-
-      - name: Install dependencies on win32
-        if: matrix.envinfo.bdist-platform == 'win32' && (matrix.envinfo.python-version == '3.8.x' || matrix.envinfo.python-version == '3.9.x')
-        run: |
-          python -m pip install scipy==1.8.1
-          python -m pip install pandas==1.2.5
 
       - name: Install dependencies from requirements.txt
         run: |
@@ -299,7 +262,7 @@ jobs:
     strategy:
       matrix:
         envinfo:
-          - { name: 'linux-3.9-x64', os: ubuntu-22.04, python-version: 3.9.x, python-arch: x64, bdist-platform: 'linux_x86_64' }
+          - { name: 'linux-3.11-x64', os: ubuntu-22.04, python-version: 3.11.x, python-arch: x64, bdist-platform: 'linux_x86_64' }
 
     env:
       PYTHONIOENCODING: "utf-8"


### PR DESCRIPTION
…, and Windows

remove deprecated Python 3.7 tests and adjust dependency installation conditions