### PR TITLE
update CI workflow to use Windows 2022 for Python 3.11 - 3.14 builds …

### DIFF
--- a/.github/workflows/run-tqsdk.yml
+++ b/.github/workflows/run-tqsdk.yml
@@ -58,10 +58,10 @@ jobs:
           - { name: 'macos-3.12-x64', os: macos-15-intel, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'macos-3.13-x64', os: macos-15-intel, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'macos-3.14-x64', os: macos-15-intel, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'windows-3.11-x64', os: windows-latest, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.12-x64', os: windows-latest, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.13-x64', os: windows-latest, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.14-x64', os: windows-latest, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.11-x64', os: windows-2022, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.12-x64', os: windows-2022, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.13-x64', os: windows-2022, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.14-x64', os: windows-2022, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
     env:
       PYTHONUNBUFFERED: 1
       PYTHONIOENCODING: "utf-8"
@@ -162,10 +162,10 @@ jobs:
           - { name: 'macos-3.12-x64', os: macos-15-intel, python-version: 3.12.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'macos-3.13-x64', os: macos-15-intel, python-version: 3.13.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
           - { name: 'macos-3.14-x64', os: macos-15-intel, python-version: 3.14.x, python-arch: x64, TZ: 'Asia/Shanghai', bdist-platform: 'any' }
-          - { name: 'windows-3.11-x64', os: windows-latest, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.12-x64', os: windows-latest, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.13-x64', os: windows-latest, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
-          - { name: 'windows-3.14-x64', os: windows-latest, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.11-x64', os: windows-2022, python-version: 3.11.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.12-x64', os: windows-2022, python-version: 3.12.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.13-x64', os: windows-2022, python-version: 3.13.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
+          - { name: 'windows-3.14-x64', os: windows-2022, python-version: 3.14.x, python-arch: x64, TZ: 'CST-8', bdist-platform: 'win_amd64' }
 
 
     env:


### PR DESCRIPTION
…in run-tqsdk.yml